### PR TITLE
Remove logger dependency

### DIFF
--- a/shopify_theme_builder.gemspec
+++ b/shopify_theme_builder.gemspec
@@ -35,7 +35,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "activesupport", ">= 6.0", "< 9.0"
   spec.add_dependency "filewatcher", "~> 2.1"
-  spec.add_dependency "logger", "~> 1.7"
   spec.add_dependency "tailwindcss-ruby", ">= 3.0", "< 5.0"
   spec.add_dependency "thor", "~> 1.4"
 end


### PR DESCRIPTION
Logger is already a dependency of the Filewatcher gem. Ref: filewatcher/filewatcher#289